### PR TITLE
fix: Add site prefix in config

### DIFF
--- a/cmd/zettel/build.go
+++ b/cmd/zettel/build.go
@@ -79,7 +79,7 @@ func (hub *Hub) build(cliCtx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	err = pipeline.ReplaceLinks(posts)
+	err = pipeline.ReplaceLinks(posts, hub.Config.SitePrefix)
 	if err != nil {
 		return err
 	}

--- a/cmd/zettel/config.go
+++ b/cmd/zettel/config.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"log"
+	"strings"
 
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/parsers/toml"
@@ -20,6 +22,20 @@ func initConfig(c *cli.Context) (Config, error) {
 	}
 	// Read the configuration and load it to internal struct.
 	err := ko.Unmarshal("", &cfg)
+
+	// Sanitize site prefix
+	var (
+		sitePrefix string
+	)
+	if cfg.SitePrefix != "" {
+		if !strings.HasPrefix(cfg.SitePrefix, "/") {
+			sitePrefix = fmt.Sprintf("/%s", cfg.SitePrefix)
+		}
+		if strings.HasSuffix(cfg.SitePrefix, "/") {
+			sitePrefix = strings.TrimSuffix(sitePrefix, "/")
+		}
+	}
+	cfg.SitePrefix = sitePrefix
 	return cfg, err
 }
 

--- a/cmd/zettel/models.go
+++ b/cmd/zettel/models.go
@@ -5,4 +5,5 @@ type Config struct {
 	SiteName      string `toml:"site_name" koanf:"site_name"`
 	Description   string `toml:"description" koanf:"description"`
 	Pygmentsstyle string `toml:"pygmentsstyle" koanf:"pygmentsstyle"`
+	SitePrefix    string `toml:"site_prefix,omitempty" koanf:"site_prefix"`
 }

--- a/cmd/zettel/render.go
+++ b/cmd/zettel/render.go
@@ -12,9 +12,7 @@ import (
 )
 
 func (hub *Hub) renderIndex(post pipeline.Post) error {
-	tmplContext := make(map[string]interface{})
-	tmplContext["SiteName"] = hub.Config.SiteName
-	tmplContext["Description"] = hub.Config.Description
+	tmplContext := getInitialTmplContext(hub.Config)
 	tmplContext["IsIndex"] = true
 	tmplContext["Post"] = post
 
@@ -39,9 +37,7 @@ func (hub *Hub) renderIndex(post pipeline.Post) error {
 }
 
 func (hub *Hub) renderPost(post pipeline.Post) error {
-	tmplContext := make(map[string]interface{})
-	tmplContext["SiteName"] = hub.Config.SiteName
-	tmplContext["Description"] = hub.Config.Description
+	tmplContext := getInitialTmplContext(hub.Config)
 	tmplContext["IsIndex"] = false
 	tmplContext["Post"] = post
 
@@ -76,9 +72,7 @@ func (hub *Hub) renderTag(tag string, posts []pipeline.Post, isAllPosts bool) er
 		}
 		links = append(links, l)
 	}
-	tmplContext := make(map[string]interface{})
-	tmplContext["SiteName"] = hub.Config.SiteName
-	tmplContext["Description"] = hub.Config.Description
+	tmplContext := getInitialTmplContext(hub.Config)
 	tmplContext["TagName"] = tag
 	tmplContext["Links"] = links
 	path := filepath.Join(defaultDistDir, "all.html")
@@ -127,10 +121,7 @@ func (hub *Hub) renderGraphData(graphData GraphData) error {
 		"templates/layouts/footer.tmpl",
 	}
 
-	tmplContext := make(map[string]interface{})
-	tmplContext["SiteName"] = hub.Config.SiteName
-	tmplContext["Description"] = hub.Config.Description
-
+	tmplContext := getInitialTmplContext(hub.Config)
 	err = saveResource("graph", tmpls, file, tmplContext, hub.Fs)
 	if err != nil {
 		return err

--- a/cmd/zettel/utils.go
+++ b/cmd/zettel/utils.go
@@ -71,3 +71,11 @@ func createDirectory(dir string) error {
 	}
 	return err
 }
+
+func getInitialTmplContext(cfg Config) map[string]interface{} {
+	tmplContext := make(map[string]interface{})
+	tmplContext["SiteName"] = cfg.SiteName
+	tmplContext["Description"] = cfg.Description
+	tmplContext["SitePrefix"] = cfg.SitePrefix
+	return tmplContext
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -72,7 +72,7 @@ func ReadFiles(directory string) ([]Post, error) {
 }
 
 // ReplaceLinks replaces all the `[[]]` links in the body with the link to the HTML page.
-func ReplaceLinks(posts []Post) error {
+func ReplaceLinks(posts []Post, sitePrefix string) error {
 	// First we need a map of all the files, so that we know
 	// if there's a link to any non existent file and also
 	// to get the metadata of the file
@@ -97,7 +97,7 @@ func ReplaceLinks(posts []Post) error {
 				return fmt.Errorf("link to an invalid slug: %s", sg)
 			}
 
-			link := fmt.Sprintf(`[%s](/posts/%s.html)`, meta.Title, sg)
+			link := fmt.Sprintf(`[%s](%s/posts/%s.html)`, meta.Title, sitePrefix, sg)
 
 			// Replace the slug with a link
 			posts[i].Body = strings.ReplaceAll(posts[i].Body, m, link)

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -37,7 +37,7 @@ func TestReplaceLinks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ReplaceLinks(posts)
+	err = ReplaceLinks(posts, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func TestConvertMarkdownToHTML(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ReplaceLinks(posts)
+	err = ReplaceLinks(posts, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/templates/layouts/header.tmpl
+++ b/templates/layouts/header.tmpl
@@ -10,8 +10,8 @@
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
     </style>
     <!-- Link to CSS -->
-    <link rel="stylesheet" type="text/css" href="/css/wing.css" />
-    <link rel="stylesheet" type="text/css" href="/css/main.css" />
+    <link rel="stylesheet" type="text/css" href="{{.SitePrefix}}/css/wing.css" />
+    <link rel="stylesheet" type="text/css" href="{{.SitePrefix}}/css/main.css" />
     <! -- Load Sigma Scripts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/sigma.js/1.2.1/sigma.min.js" integrity="sha512-4+XX9O3GEcpTWGNW7m3w/ORF91L4zUX01/U3wAoWIXp1P+LRBEqutZdQIFUeHSa0cJRZ9LPM+GOWus8h8TlYhg==" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/sigma.js/1.2.1/plugins/sigma.parsers.json.min.js" integrity="sha512-uhhcXJvqfQpnVqJRyCs49Ddt16zZ35qFokRiVOZei14sbMdMS9vtubrb1QQvGJ/zQhQbCttBvVJqqiZHrsHo1g==" crossorigin="anonymous"></script>

--- a/templates/layouts/list.tmpl
+++ b/templates/layouts/list.tmpl
@@ -13,9 +13,9 @@
             <ul>
             {{- range .Links}}
                 {{- if eq .Slug "index"}}
-                    <li><a href="/">{{.Title}}</a></li>
+                    <li><a href="{{$.SitePrefix}}">{{.Title}}</a></li>
                 {{- else}}
-                    <li><a href="/posts/{{.Slug}}.html">{{.Title}}</a></li>
+                    <li><a href="{{$.SitePrefix}}/posts/{{.Slug}}.html">{{.Title}}</a></li>
                 {{- end}} 
             {{- end}}
             </ul>

--- a/templates/layouts/navbar.tmpl
+++ b/templates/layouts/navbar.tmpl
@@ -1,8 +1,8 @@
 {{ define "navbar" }}
 
 <navbar class="horizontal-align">
-    <div class="nav-item"><a href="/">Home</a></div>
-    <div class="nav-item"><a href="/all.html">All Zettels</a></div>
-    <div class="nav-item"><a href="/graph.html">Graph</a></div>
+    <div class="nav-item"><a href="{{.SitePrefix}}/">Home</a></div>
+    <div class="nav-item"><a href="{{.SitePrefix}}/all.html">All Zettels</a></div>
+    <div class="nav-item"><a href="{{.SitePrefix}}/graph.html">Graph</a></div>
 </navbar>
 {{- end }}

--- a/templates/layouts/post.tmpl
+++ b/templates/layouts/post.tmpl
@@ -16,9 +16,9 @@
             <ul>
                 {{- range .Post.Connections}}
                     {{- if eq .Slug "index"}}
-                        <li><a href="/">{{.Title}}</a></li>
+                        <li><a href="{{$.SitePrefix}}/">{{.Title}}</a></li>
                     {{- else}}
-                        <li><a href="/posts/{{.Slug}}.html">{{.Title}}</a></li>
+                        <li><a href="{{$.SitePrefix}}/posts/{{.Slug}}.html">{{.Title}}</a></li>
                     {{- end}}    
                 {{- end}}
             </ul>
@@ -28,7 +28,7 @@
 {{- if .Post.Meta.Tags}}
     <section class="container tags">
         {{- range $t := .Post.Meta.Tags}}
-            <a href="/tags/{{$t}}.html"><button class='outline'>{{$t}}</button></a>
+            <a href="{{$.SitePrefix}}/tags/{{$t}}.html"><button class='outline'>{{$t}}</button></a>
         {{- end}}
     </section>
 {{- end}}


### PR DESCRIPTION
User can give `site_prefix` in `zettle.toml`. This allows to host the pages under a path prefix. For e.g, the user can host the files under `https://example.com/prefix/`. Previously the links generated where from `/` which doesn't work if the user hosts it under a prefix.
This should fix #20.