### PR TITLE
Add support for disk filesystems

### DIFF
--- a/cmd/zettel/build.go
+++ b/cmd/zettel/build.go
@@ -15,7 +15,15 @@ func (hub *Hub) BuildSite() *cli.Command {
 		Name:    "build",
 		Aliases: []string{"b"},
 		Usage:   "Builds a static dist of all notes ready to be published on web.",
-		Action:  hub.MustHaveConfig(hub.build),
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "filesystem",
+				Aliases: []string{"f"},
+				Usage:   "Specify path to templates root filesystem",
+				Value:   "builtin",
+			},
+		},
+		Action: hub.MustInitFileSystem(hub.MustHaveConfig(hub.build)),
 	}
 }
 

--- a/cmd/zettel/fs.go
+++ b/cmd/zettel/fs.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/knadh/stuffbin"
+)
+
+type FileSystem interface {
+	Glob(string) ([]string, error)
+	Read(string) ([]byte, error)
+}
+
+// assert that filesystem.StuffBin implements FileSystem in compile time
+var _ FileSystem = (stuffbin.FileSystem)(nil)
+
+// initBuiltinFileSystem initializes the stuffbin FileSystem to provide
+// access to bunded static assets to the app.
+func initBuiltinFileSystem() (stuffbin.FileSystem, error) {
+	ex, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
+
+	exPath := filepath.Dir(ex)
+	fs, err := stuffbin.UnStuff(filepath.Join(exPath, filepath.Base(os.Args[0])))
+	if err != nil {
+		return nil, err
+	}
+
+	return fs, nil
+}
+
+type DiskFileSystem struct {
+	root string
+}
+
+func initDiskFileSystem(dir string) (FileSystem, error) {
+	dir = strings.TrimSuffix(dir, "/")
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", dir)
+	}
+
+	return &DiskFileSystem{root: dir}, nil
+}
+
+func (disk *DiskFileSystem) Glob(pattern string) ([]string, error) {
+	matches, err := filepath.Glob(filepath.Join(disk.root, pattern))
+	if err != nil {
+		return nil, nil
+	}
+
+	for i, value := range matches {
+		matches[i] = strings.TrimPrefix(value, disk.root)
+	}
+
+	return matches, nil
+}
+
+func (disk *DiskFileSystem) Read(relative string) ([]byte, error) {
+	return ioutil.ReadFile(filepath.Join(disk.root, relative))
+}

--- a/cmd/zettel/hub.go
+++ b/cmd/zettel/hub.go
@@ -9,7 +9,7 @@ import (
 type Hub struct {
 	Logger  *logrus.Logger
 	Config  Config
-	Fs      stuffbin.FileSystem
+	Fs      FileSystem
 	Version string
 }
 

--- a/cmd/zettel/main.go
+++ b/cmd/zettel/main.go
@@ -3,9 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
-	"github.com/knadh/stuffbin"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
@@ -34,24 +32,6 @@ func initLogger(verbose bool) *logrus.Logger {
 	return logger
 }
 
-// initFileSystem initializes the stuffbin FileSystem to provide
-// access to bunded static assets to the app.
-func initFileSystem() (stuffbin.FileSystem, error) {
-	ex, err := os.Executable()
-	if err != nil {
-		panic(err)
-	}
-
-	exPath := filepath.Dir(ex)
-	fs, err := stuffbin.UnStuff(filepath.Join(exPath, filepath.Base(os.Args[0])))
-
-	if err != nil {
-		return nil, err
-	}
-
-	return fs, nil
-}
-
 func main() {
 	// Intialize new CLI app
 	app := cli.NewApp()
@@ -71,11 +51,11 @@ func main() {
 		},
 	}
 
-	var logger = initLogger(true)
+	logger := initLogger(true)
 
 	// Initialize the static file system into which all
 	// required static assets (.css, .js files etc.) are loaded.
-	fs, err := initFileSystem()
+	fs, err := initBuiltinFileSystem()
 	if err != nil {
 		logger.Errorf("error reading stuffed binary: %s", err)
 	}

--- a/cmd/zettel/middleware.go
+++ b/cmd/zettel/middleware.go
@@ -21,3 +21,21 @@ func (hub *Hub) MustHaveConfig(fn cli.ActionFunc) cli.ActionFunc {
 		return fn(c)
 	}
 }
+
+func (hub *Hub) MustInitFileSystem(fn cli.ActionFunc) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		fs := c.String("filesystem")
+		if fs == "builtin" {
+			return fn(c)
+		}
+
+		disk, err := initDiskFileSystem(fs)
+		if err != nil {
+			log.Fatalf("error while initializing disk filesystem %q: %v", fs, err)
+		}
+
+		hub.Fs = disk
+
+		return fn(c)
+	}
+}

--- a/cmd/zettel/utils.go
+++ b/cmd/zettel/utils.go
@@ -5,8 +5,6 @@ import (
 	"io"
 	"os"
 	"text/template"
-
-	"github.com/knadh/stuffbin"
 )
 
 // createFile takes a default config template file and writes to the current directory
@@ -25,7 +23,7 @@ func createFile(cfgFile []byte, configName string) error {
 
 // parse takes in a template path and the variables to be "applied" on it. The rendered template
 // is saved to the destination path.
-func parse(name string, templateNames []string, fs stuffbin.FileSystem) (*template.Template, error) {
+func parse(name string, templateNames []string, fs FileSystem) (*template.Template, error) {
 	tmpl := template.New(name)
 
 	for _, t := range templateNames {
@@ -49,7 +47,7 @@ func writeTemplate(tmpl *template.Template, config map[string]interface{}, dest 
 	return tmpl.Execute(dest, config)
 }
 
-func saveResource(name string, templateNames []string, dest io.Writer, config map[string]interface{}, fs stuffbin.FileSystem) error {
+func saveResource(name string, templateNames []string, dest io.Writer, config map[string]interface{}, fs FileSystem) error {
 	// parse template file
 	tmpl, err := parse(name, templateNames, fs)
 	if err != nil {


### PR DESCRIPTION
This feature adds a new abstraction layer — FileSystem which is derived from
stuffbin.FileSystem.

It allows users to specify a custom directory that contains /templates/
subdirectory. Which means users can build their custom zettel dists without
re-building whole program.

```
$ zettel build -f .
```

This command will make zettel build `dist/` using `templates/` directory located
in the current directory.